### PR TITLE
Use equal symbols in sample .env file

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,20 +8,20 @@ APP_ENV=prod
 APP_SECRET=changeme
 
 # URL under which this application is available
-APP_URL: "https://tracky.example.com"
+APP_URL="https://tracky.example.com"
 
 # Database driver to use (only "pdo_mysql" is supported but others might work as well)
-DATABASE_DRIVER: pdo_mysql
+DATABASE_DRIVER=pdo_mysql
 
 # Hostname or IP address of your database server
-DATABASE_HOST: your.database.host
+DATABASE_HOST=your.database.host
 
 # Database name to use
-DATABASE_NAME: tracky
+DATABASE_NAME=tracky
 
 # Database credentials (username and password)
-DATABASE_USERNAME: some-username
-DATABASE_PASSWORD: some-password
+DATABASE_USERNAME=some-username
+DATABASE_PASSWORD=some-password
 
 # Database server version (should be exactly as reported by the database server)
-DATABASE_SERVER_VERSION: "11.1.2-MariaDB"
+DATABASE_SERVER_VERSION="11.1.2-MariaDB"


### PR DESCRIPTION
Otherwise, I would get:

`PHP Fatal error:  Uncaught Symfony\\Component\\Dotenv\\Exception\\FormatException: Missing = in the environment variable declaration`