### PR TITLE
Set missing ViewType on movie+show controllers

### DIFF
--- a/src/main/php/tracky/controller/MovieController.php
+++ b/src/main/php/tracky/controller/MovieController.php
@@ -169,6 +169,7 @@ class MovieController extends AbstractController
         $view->setItem($movie);
         $view->setUser($this->getUser());
         $view->setDateTime($dateTime);
+        $view->setType(ViewType::MOVIE);
 
         $entityManager->persist($view);
         $entityManager->flush();

--- a/src/main/php/tracky/controller/ShowController.php
+++ b/src/main/php/tracky/controller/ShowController.php
@@ -217,6 +217,7 @@ class ShowController extends AbstractController
         $view->setItem($episode);
         $view->setUser($this->getUser());
         $view->setDateTime($dateTime);
+        $view->setType(ViewType::EPISODE);
 
         $entityManager->persist($view);
         $entityManager->flush();


### PR DESCRIPTION
Without these, watch times cannot be tracked, because an unset type would result in an empty database column, which is not permitted:

`Uncaught PHP Exception Doctrine\\DBAL\\Exception\\NotNullConstraintViolationException: "An exception occurred while executing a query: SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'type' cannot be null" at ExceptionConverter.php line 126'`