### PR TITLE
[Feature] Implement methods and GUI elements to mark whole seasons as watched (or unwatched)

### DIFF
--- a/src/main/php/tracky/controller/ShowController.php
+++ b/src/main/php/tracky/controller/ShowController.php
@@ -193,6 +193,36 @@ class ShowController extends AbstractController
         ]);
     }
 
+    #[Route("/shows/{show}/seasons/{seasonNumber}/views", name: "shows_add_season_view_action", methods: ["POST"])]
+    #[IsGranted("IS_AUTHENTICATED")]
+    public function addSeasonView(Show $show, int $seasonNumber, Request $request, EntityManagerInterface $entityManager): Response
+    {
+        $season = $show->getSeason($seasonNumber);
+        if ($season === null) {
+            throw new NotFoundHttpException("Season not found");
+        }
+
+        try {
+            $dateTime = new DateTime($request->getPayload()->get("timestamp"));
+        } catch (Exception) {
+            throw new BadRequestException("Invalid payload");
+        }
+
+        foreach ($season->getEpisodes() as $episode) {
+            $view = new View;
+            $view->setItem($episode);
+            $view->setUser($this->getUser());
+            $view->setDateTime($dateTime);
+            $view->setType(ViewType::EPISODE);
+
+            $entityManager->persist($view);
+        }
+
+        $entityManager->flush();
+
+        return new Response("Season views added to database");
+    }
+
     #[Route("/shows/{show}/seasons/{seasonNumber}/episodes/{episodeNumber}/views", name: "shows_add_episode_view_action", methods: ["POST"])]
     #[IsGranted("IS_AUTHENTICATED")]
     public function addView(Show $show, int $seasonNumber, int $episodeNumber, Request $request, EntityManagerInterface $entityManager): Response

--- a/src/main/php/tracky/controller/ShowController.php
+++ b/src/main/php/tracky/controller/ShowController.php
@@ -223,6 +223,22 @@ class ShowController extends AbstractController
         return new Response("Season views added to database");
     }
 
+    #[Route("/shows/{show}/seasons/{seasonNumber}/views/all", name: "shows_remove_season_view_action", methods: ["DELETE"])]
+    #[IsGranted("IS_AUTHENTICATED")]
+    public function removeViewsBySeason(Show $show, int $seasonNumber, ViewRepository $viewRepository, EntityManagerInterface $entityManager): Response
+    {
+        $season = $show->getSeason($seasonNumber);
+        if ($season === null) {
+            throw new NotFoundHttpException("Season not found");
+        }
+
+        foreach ($season->getEpisodes() as $episode) {
+            $this->removeViewsByEpisode($show, $seasonNumber, $episode->getNumber(), $viewRepository, $entityManager);
+        }
+
+        return new Response("Season views removed from database");
+    }
+
     #[Route("/shows/{show}/seasons/{seasonNumber}/episodes/{episodeNumber}/views", name: "shows_add_episode_view_action", methods: ["POST"])]
     #[IsGranted("IS_AUTHENTICATED")]
     public function addView(Show $show, int $seasonNumber, int $episodeNumber, Request $request, EntityManagerInterface $entityManager): Response

--- a/src/main/php/tracky/controller/ShowController.php
+++ b/src/main/php/tracky/controller/ShowController.php
@@ -1,6 +1,7 @@
 <?php
 namespace tracky\controller;
 
+use DateInterval;
 use Doctrine\ORM\EntityManagerInterface;
 use Exception;
 use RuntimeException;
@@ -208,14 +209,24 @@ class ShowController extends AbstractController
             throw new BadRequestException("Invalid payload");
         }
 
-        foreach ($season->getEpisodes() as $episode) {
+        $episodes = $season->getEpisodes();
+        if (!is_array($episodes)) {
+            $episodes = iterator_to_array($episodes);
+        }
+
+        foreach (array_reverse($episodes) as $episode) {
             $view = new View;
             $view->setItem($episode);
             $view->setUser($this->getUser());
-            $view->setDateTime($dateTime);
+            $view->setDateTime(clone $dateTime);
             $view->setType(ViewType::EPISODE);
 
             $entityManager->persist($view);
+
+            $runtime = $episode->getRuntime();
+            if ($runtime !== null && $runtime > 0) {
+                $dateTime->sub(new DateInterval(sprintf("PT%dM", $runtime)));
+            }
         }
 
         $entityManager->flush();

--- a/src/main/resources/assets/script/view.ts
+++ b/src/main/resources/assets/script/view.ts
@@ -22,46 +22,84 @@ function addView(url: string, date: Date) {
     });
 }
 
+function removeViews(url: string) {
+    fetch(url, {
+        method: "DELETE"
+    }).then(() => {
+        document.location.reload();
+    });
+}
+
 document.addEventListener("DOMContentLoaded", () => {
-    let tooltipElement: HTMLElement = document.querySelector("#add-view-tooltip");
-    let activeEntry: DOMStringMap = null;
+    let addViewTooltipElement: HTMLElement = document.querySelector("#add-view-tooltip");
+    let removeSeasonViewTooltipElement: HTMLElement = document.querySelector("#season-remove-view-tooltip");
+    let activeAddViewEntry: DOMStringMap = null;
+    let activeRemoveSeasonViewEntry: DOMStringMap = null;
 
     document.querySelectorAll(".add-view").forEach((buttonElement: HTMLElement) => {
         buttonElement.addEventListener("click", () => {
-            createPopper(buttonElement, tooltipElement, {
+            createPopper(buttonElement, addViewTooltipElement, {
                 placement: "bottom"
             });
 
-            tooltipElement.style.display = "block";
-            activeEntry = buttonElement.dataset;
+            addViewTooltipElement.style.display = "block";
+            activeAddViewEntry = buttonElement.dataset;
 
             useNow();
+        });
+    });
+
+    document.querySelectorAll(".remove-view").forEach((buttonElement: HTMLElement) => {
+        buttonElement.addEventListener("click", () => {
+            createPopper(buttonElement, removeSeasonViewTooltipElement, {
+                placement: "bottom"
+            });
+
+            removeSeasonViewTooltipElement.style.display = "block";
+            activeRemoveSeasonViewEntry = buttonElement.dataset;
         });
     });
 
     document.querySelector("#add-view-tooltip-form")?.addEventListener("submit", (event) => {
         event.preventDefault();
 
-        if (activeEntry === null) {
+        if (activeAddViewEntry === null) {
             return;
         }
 
         let dateTimeElement = document.querySelector("#add-view-tooltip-datetime") as HTMLInputElement;
         let dateTime = new Date(Date.parse(dateTimeElement.value));
 
-        switch (activeEntry.type) {
+        switch (activeAddViewEntry.type) {
             case "episode":
-                addView(`/shows/${activeEntry.showId}/seasons/${activeEntry.season}/episodes/${activeEntry.episode}/views`, dateTime);
+                addView(`/shows/${activeAddViewEntry.showId}/seasons/${activeAddViewEntry.season}/episodes/${activeAddViewEntry.episode}/views`, dateTime);
                 break;
 
             case "season":
-                addView(`/shows/${activeEntry.showId}/seasons/${activeEntry.season}/views`, dateTime);
+                addView(`/shows/${activeAddViewEntry.showId}/seasons/${activeAddViewEntry.season}/views`, dateTime);
                 break;
 
             case "movie":
-                addView(`/movies/${activeEntry.movieId}/views`, dateTime);
+                addView(`/movies/${activeAddViewEntry.movieId}/views`, dateTime);
                 break;
         }
+    });
+
+    document.querySelector("#season-remove-view-tooltip-confirm")?.addEventListener("click", () => {
+        if (activeRemoveSeasonViewEntry === null) {
+            return;
+        }
+
+        switch (activeRemoveSeasonViewEntry.type) {
+            case "season":
+                removeViews(`/shows/${activeRemoveSeasonViewEntry.showId}/seasons/${activeRemoveSeasonViewEntry.season}/views/all`);
+                break;
+        }
+    });
+
+    document.querySelector("#season-remove-view-tooltip-cancel")?.addEventListener("click", () => {
+        removeSeasonViewTooltipElement.style.display = "none";
+        activeRemoveSeasonViewEntry = null;
     });
 
     document.querySelector("#add-view-tooltip-now")?.addEventListener("click", () => {
@@ -69,7 +107,7 @@ document.addEventListener("DOMContentLoaded", () => {
     });
 
     document.querySelector("#add-view-tooltip-cancel")?.addEventListener("click", () => {
-        tooltipElement.style.display = "none";
-        activeEntry = null;
+        addViewTooltipElement.style.display = "none";
+        activeAddViewEntry = null;
     });
 });

--- a/src/main/resources/assets/script/view.ts
+++ b/src/main/resources/assets/script/view.ts
@@ -54,6 +54,10 @@ document.addEventListener("DOMContentLoaded", () => {
                 addView(`/shows/${activeEntry.showId}/seasons/${activeEntry.season}/episodes/${activeEntry.episode}/views`, dateTime);
                 break;
 
+            case "season":
+                addView(`/shows/${activeEntry.showId}/seasons/${activeEntry.season}/views`, dateTime);
+                break;
+
             case "movie":
                 addView(`/movies/${activeEntry.movieId}/views`, dateTime);
                 break;

--- a/src/main/resources/lang/messages+intl-icu.de.yaml
+++ b/src/main/resources/lang/messages+intl-icu.de.yaml
@@ -142,10 +142,12 @@ views:
   views: "{count} mal gesehen"
   add-view: "Als gesehen markieren"
   add-season-view: "Alle Folgen der Staffel als gesehen markieren"
+  remove-season-view: "Gesehen-Status aller Folgen der Staffel zurücksetzen"
   show-all-views: "Gesamten Verlauf anzeigen"
   last-watched: "Zuletzt gesehen"
   remove:
     header: "Verlauf entfernen?"
+    season-views: "Alle Ansichten dieser Staffel entfernen?"
     this-view: "Diesen Eintrag"
     all-views: "Alle Einträge"
     cancel: "Abbrechen"

--- a/src/main/resources/lang/messages+intl-icu.de.yaml
+++ b/src/main/resources/lang/messages+intl-icu.de.yaml
@@ -141,6 +141,7 @@ movies:
 views:
   views: "{count} mal gesehen"
   add-view: "Als gesehen markieren"
+  add-season-view: "Alle Folgen der Staffel als gesehen markieren"
   show-all-views: "Gesamten Verlauf anzeigen"
   last-watched: "Zuletzt gesehen"
   remove:

--- a/src/main/resources/lang/messages+intl-icu.en.yaml
+++ b/src/main/resources/lang/messages+intl-icu.en.yaml
@@ -145,6 +145,7 @@ views:
       other {# views}
     }
   add-view: "Add view"
+  add-season-view: "Mark all episodes of season as watched"
   show-all-views: "Show all views"
   last-watched: "Last watched"
   remove:

--- a/src/main/resources/lang/messages+intl-icu.en.yaml
+++ b/src/main/resources/lang/messages+intl-icu.en.yaml
@@ -146,10 +146,12 @@ views:
     }
   add-view: "Add view"
   add-season-view: "Mark all episodes of season as watched"
+  remove-season-view: "Remove watched status of all episodes in the season"
   show-all-views: "Show all views"
   last-watched: "Last watched"
   remove:
     header: "Remove history entries?"
+    season-views: "Remove all views of this season?"
     this-view: "This view"
     all-views: "All views"
     cancel: "Cancel"

--- a/templates/page.twig
+++ b/templates/page.twig
@@ -111,6 +111,18 @@
             </div>
         </div>
 
+        <div id="season-remove-view-tooltip" class="popper">
+            <div data-popper-arrow></div>
+
+            <div class="card">
+                <div class="card-header">{{ "views.remove.header"|trans }}</div>
+                <div class="card-body">
+                    <button class="btn btn-sm btn-danger" id="season-remove-view-tooltip-confirm">{{ "views.remove.season-views"|trans }}</button>
+                    <button class="btn btn-sm btn-secondary" id="season-remove-view-tooltip-cancel">{{ "views.remove.cancel"|trans }}</button>
+                </div>
+            </div>
+        </div>
+
         <div id="add-view-tooltip" class="popper">
             <div data-popper-arrow></div>
 

--- a/templates/shows/season.twig
+++ b/templates/shows/season.twig
@@ -40,7 +40,7 @@
         </div>
     </div>
 
-    <div class="my-3 gap-2 d-flex">
+    <div class="my-3 gap-2 d-flex align-items-center">
         <h2 class="my-0">{{ "shows.episodes"|trans }}</h2>
         {% if is_granted("IS_AUTHENTICATED") %}
             <button
@@ -51,6 +51,15 @@
                     title="{{ "views.add-season-view"|trans }}"
             >
                 <i class="fa fa-check"></i>
+            </button>
+            <button
+                    class="btn btn-danger btn-sm remove-view"
+                    data-type="season"
+                    data-show-id="{{ show.id }}"
+                    data-season="{{ season.number }}"
+                    title="{{ "views.remove-season-view"|trans }}"
+            >
+                <i class="fa fa-trash"></i>
             </button>
         {% endif %}
     </div>

--- a/templates/shows/season.twig
+++ b/templates/shows/season.twig
@@ -40,7 +40,20 @@
         </div>
     </div>
 
-    <h2 class="my-3">{{ "shows.episodes"|trans }}</h2>
+    <div class="my-3 gap-2 d-flex">
+        <h2 class="my-0">{{ "shows.episodes"|trans }}</h2>
+        {% if is_granted("IS_AUTHENTICATED") %}
+            <button
+                    class="btn btn-success btn-sm add-view ms-2"
+                    data-type="season"
+                    data-show-id="{{ show.id }}"
+                    data-season="{{ season.number }}"
+                    title="{{ "views.add-season-view"|trans }}"
+            >
+                <i class="fa fa-check"></i>
+            </button>
+        {% endif %}
+    </div>
 
     {% set previousSeason = season.previousSeason %}
     {% if previousSeason %}


### PR DESCRIPTION
This adds two new buttons to the season overview page:

<img width="783" height="441" alt="image" src="https://github.com/user-attachments/assets/7719f57f-d6b2-4d1f-9894-a8c79573cb9e" />

Marking a whole season as watched will go through each episode and add a view. Since the user can provide a time (just like with a single episode), the runtime of each episode is considered and all of the episodes are chained back-to-back until that time is reached.

<img width="630" height="796" alt="image" src="https://github.com/user-attachments/assets/b2e943ec-b205-4760-9afd-c4de7fea5a53" />

Marking a whole season as unwatched will remove all views from all episodes in that season. Since it's very destructive, it has to be confirmed first.

<img width="452" height="197" alt="image" src="https://github.com/user-attachments/assets/b342047b-744e-43bc-bd7c-bb0cff0f28e3" />

This is very useful for new users of Tracky (like me), so they don't have to go through each episode of a series individually and mark them as watched when they're already in the middle of a series.