### PR TITLE
Implement tracking episode views without page reloads

### DIFF
--- a/src/main/php/tracky/controller/ShowController.php
+++ b/src/main/php/tracky/controller/ShowController.php
@@ -252,7 +252,14 @@ class ShowController extends AbstractController
 
     #[Route("/shows/{show}/seasons/{seasonNumber}/episodes/{episodeNumber}/views", name: "shows_add_episode_view_action", methods: ["POST"])]
     #[IsGranted("IS_AUTHENTICATED")]
-    public function addView(Show $show, int $seasonNumber, int $episodeNumber, Request $request, EntityManagerInterface $entityManager): Response
+    public function addView(
+        Show $show,
+        int $seasonNumber,
+        int $episodeNumber,
+        Request $request,
+        EntityManagerInterface $entityManager,
+        WatchStatsProvider $watchStatsProvider
+    ): Response
     {
         $season = $show->getSeason($seasonNumber);
         if ($season === null) {
@@ -279,7 +286,11 @@ class ShowController extends AbstractController
         $entityManager->persist($view);
         $entityManager->flush();
 
-        return new Response("View added to database");
+        return $this->render("components/view-last-watched.twig", [
+            "type" => "episode",
+            "item" => $episode,
+            "watchStatsProvider" => $watchStatsProvider,
+        ]);
     }
 
     #[Route("/shows/{show}/seasons/{seasonNumber}/episodes/{episodeNumber}/views/all", name: "shows_remove_episode_view_action", methods: ["DELETE"])]

--- a/src/main/resources/assets/script/view.ts
+++ b/src/main/resources/assets/script/view.ts
@@ -9,7 +9,7 @@ function useNow() {
 }
 
 function addView(url: string, date: Date) {
-    fetch(url, {
+    return fetch(url, {
         method: "POST",
         headers: {
             "Content-Type": "application/json"
@@ -17,8 +17,34 @@ function addView(url: string, date: Date) {
         body: JSON.stringify({
             "timestamp": date.toISOString()
         })
-    }).then(() => {
-        document.location.reload();
+    });
+}
+
+function addEpisodeView(url: string, date: Date, entry: DOMStringMap): void {
+    addView(url, date)
+        .then((response) => {
+            if (!response.ok) {
+                throw new Error("Unable to add episode view");
+            }
+
+            return response.text();
+        })
+        .then((html) => {
+            let lastWatchedElement = document.querySelector(
+                `.view-last-watched[data-type="episode"][data-show-id="${entry.showId}"][data-season="${entry.season}"][data-episode="${entry.episode}"]`
+            );
+
+            if (lastWatchedElement !== null) {
+                lastWatchedElement.innerHTML = html;
+            }
+        });
+}
+
+function addViewAndReload(url: string, date: Date): void {
+    addView(url, date).then((response) => {
+        if (response.ok) {
+            document.location.reload();
+        }
     });
 }
 
@@ -72,17 +98,21 @@ document.addEventListener("DOMContentLoaded", () => {
 
         switch (activeAddViewEntry.type) {
             case "episode":
-                addView(`/shows/${activeAddViewEntry.showId}/seasons/${activeAddViewEntry.season}/episodes/${activeAddViewEntry.episode}/views`, dateTime);
+                addEpisodeView(`/shows/${activeAddViewEntry.showId}/seasons/${activeAddViewEntry.season}/episodes/${activeAddViewEntry.episode}/views`, dateTime, activeAddViewEntry);
                 break;
 
             case "season":
-                addView(`/shows/${activeAddViewEntry.showId}/seasons/${activeAddViewEntry.season}/views`, dateTime);
+                addViewAndReload(`/shows/${activeAddViewEntry.showId}/seasons/${activeAddViewEntry.season}/views`, dateTime);
                 break;
 
             case "movie":
-                addView(`/movies/${activeAddViewEntry.movieId}/views`, dateTime);
+                addViewAndReload(`/movies/${activeAddViewEntry.movieId}/views`, dateTime);
                 break;
         }
+
+        // Hide the modal
+        addViewTooltipElement.style.display = "none";
+        activeAddViewEntry = null;
     });
 
     document.querySelector("#season-remove-view-tooltip-confirm")?.addEventListener("click", () => {

--- a/templates/components/episode-card-wide.twig
+++ b/templates/components/episode-card-wide.twig
@@ -27,7 +27,12 @@
 
                 <div class="card-text mt-3 card-plot">{{ episode.plot }}</div>
 
-                <div class="card-text mt-3">
+                <div class="card-text mt-3 view-last-watched"
+                     data-type="episode"
+                     data-show-id="{{ episode.season.show.id }}"
+                     data-season="{{ episode.season.number }}"
+                     data-episode="{{ episode.number }}"
+                >
                     {% include "components/view-last-watched.twig" with {"type": "episode", "item": episode} only %}
                 </div>
             </div>


### PR DESCRIPTION
By rendering the `view-last-watched.twig` template as a response of the `ShowController`'s `addView()` method, users can track episode views without having to reload the page.

For this, I added a new function `addEpisodeView()` to the frontend. Seasons and movies still use the old method, which has been renamed to `addViewAndReload()`.