### PR TITLE
Implement SettingsController & user settings page

### DIFF
--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -15,8 +15,5 @@ parameters:
   history.items-per-page: 100
   history.max-previous-next-pages: 3
   shows.max-episodes: 10
-  overview.max-episodes: 5
-  overview.max-movies: 5
-  overview.max-next-episode-shows: 5
   now-watching.storage-path: "%kernel.cache_dir%/now-watching"
   now-watching.max-age: 300

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -25,6 +25,11 @@ doctrine:
         dir: '%kernel.project_dir%/src/main/php/tracky/model'
         prefix: 'tracky\model'
         alias: tracky
+      orm:
+        is_bundle: false
+        dir: '%kernel.project_dir%/src/main/php/tracky/orm'
+        prefix: 'tracky\orm'
+        alias: orm
 
 when@test:
   doctrine:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -29,11 +29,6 @@ services:
     arguments:
       $itemsPerPage: "%history.items-per-page%"
       $maxPreviousNextPages: "%history.max-previous-next-pages%"
-  tracky\controller\HomeController:
-    arguments:
-      $maxEpisodes: "%overview.max-episodes%"
-      $maxMovies: "%overview.max-movies%"
-      $maxNextEpisodeShows: "%overview.max-next-episode-shows%"
   tracky\controller\ShowController:
     arguments:
       $maxEpisodes: "%shows.max-episodes%"

--- a/migrations/Version20260709121900.php
+++ b/migrations/Version20260709121900.php
@@ -1,0 +1,26 @@
+<?php
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260709121900 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create the settings table for storing user preferences.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE settings (id INTEGER NOT NULL AUTO_INCREMENT, user_id INTEGER NOT NULL, setting VARCHAR(255) NOT NULL, value VARCHAR(255) NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_SETTINGS_USER ON settings (user_id)');
+        $this->addSql('ALTER TABLE settings ADD CONSTRAINT FK_SETTINGS_USER FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE');
+
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE settings');
+    }
+}

--- a/src/main/php/tracky/controller/HomeController.php
+++ b/src/main/php/tracky/controller/HomeController.php
@@ -1,12 +1,14 @@
 <?php
 namespace tracky\controller;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use tracky\HistoryEntry;
 use tracky\orm\EpisodeRepository;
 use tracky\orm\MovieRepository;
+use tracky\orm\Settings;
 use tracky\orm\ShowRepository;
 use tracky\orm\ViewRepository;
 use tracky\scrobbler\Scrobbler;
@@ -16,45 +18,67 @@ use tracky\watchstats\WatchStatsProvider;
 class HomeController extends AbstractController
 {
     public function __construct(
-        private readonly int $maxEpisodes,
-        private readonly int $maxMovies,
-        private readonly int $maxNextEpisodeShows
+        private readonly SettingsController $settingsController
     )
     {
     }
 
     #[Route("/", name: "home_page")]
-    public function home(ShowRepository $showRepository, EpisodeRepository $episodeRepository, MovieRepository $movieRepository, ViewRepository $viewRepository, WatchStatsProvider $watchStatsProvider, Scrobbler $scrobbler): Response
+    public function home(
+        ShowRepository $showRepository,
+        EpisodeRepository $episodeRepository,
+        MovieRepository $movieRepository,
+        ViewRepository $viewRepository,
+        WatchStatsProvider $watchStatsProvider,
+        Scrobbler $scrobbler,
+        EntityManagerInterface $entityManager
+    ): Response
     {
         $nowWatching = null;
         $latestWatchedEpisodes = null;
         $latestWatchedMovies = null;
         $nextEpisodes = null;
 
+        // Initialize fallback values from settings schema defaults
+        $defaults = $this->settingsController->getSettingDefaults();
+        $maxEpisodes = (int)($defaults['overviewMaxEpisodes']['default'] ?? 8);
+        $maxMovies = (int)($defaults['overviewMaxMovies']['default'] ?? 8);
+        $maxNextEpisodeShows = (int)($defaults['overviewMaxNextEpisodeShows']['default'] ?? 8);
+
         $user = $this->getUser();
         if ($user !== null) {
+            $savedSettings = $entityManager->getRepository(Settings::class)->findBy(['user' => $user]);
+            foreach ($savedSettings as $setting) {
+                if ($setting->getSetting() === 'overviewMaxEpisodes') {
+                    $maxEpisodes = (int)$setting->getValue();
+                } elseif ($setting->getSetting() === 'overviewMaxMovies') {
+                    $maxMovies = (int)$setting->getValue();
+                } elseif ($setting->getSetting() === 'overviewMaxNextEpisodeShows') {
+                    $maxNextEpisodeShows = (int)$setting->getValue();
+                }
+            }
             $nowWatching = $scrobbler->getNowWatching($user);
 
-            $episodeViews = $viewRepository->findBy(["user" => $user->getId()], ["dateTime" => "desc"], $this->maxEpisodes, type: ViewType::EPISODE);
-            $movieViews = $viewRepository->findBy(["user" => $user->getId()], ["dateTime" => "desc"], $this->maxMovies, type: ViewType::MOVIE);
+            $episodeViews = $viewRepository->findBy(["user" => $user->getId()], ["dateTime" => "desc"], $maxEpisodes, type: ViewType::EPISODE);
+            $movieViews = $viewRepository->findBy(["user" => $user->getId()], ["dateTime" => "desc"], $maxMovies, type: ViewType::MOVIE);
 
             $latestWatchedEpisodes = HistoryEntry::getFromViews($episodeViews, $episodeRepository, $movieRepository, $watchStatsProvider);
             $latestWatchedMovies = HistoryEntry::getFromViews($movieViews, $episodeRepository, $movieRepository, $watchStatsProvider);
 
-            $nextEpisodes = $this->getNextEpisodes($showRepository, $watchStatsProvider);
+            $nextEpisodes = $this->getNextEpisodes($showRepository, $watchStatsProvider, $maxNextEpisodeShows);
         }
 
         return $this->render("index.twig", [
             "nowWatching" => $nowWatching,
-            "latestEpisodes" => $episodeRepository->findBy([], ["firstAired" => "DESC"], $this->maxEpisodes),
-            "latestMovies" => $movieRepository->findBy([], ["year" => "DESC"], $this->maxMovies),
+            "latestEpisodes" => $episodeRepository->findBy([], ["firstAired" => "DESC"], $maxEpisodes),
+            "latestMovies" => $movieRepository->findBy([], ["year" => "DESC"], $maxMovies),
             "latestWatchedEpisodes" => $latestWatchedEpisodes,
             "latestWatchedMovies" => $latestWatchedMovies,
             "nextEpisodes" => $nextEpisodes
         ]);
     }
 
-    private function getNextEpisodes(ShowRepository $showRepository, WatchStatsProvider $watchStatsProvider)
+    private function getNextEpisodes(ShowRepository $showRepository, WatchStatsProvider $watchStatsProvider, int $maxNextEpisodeShows)
     {
         /**
          * @var list<array{Episode, DateTime}>
@@ -78,6 +102,6 @@ class HomeController extends AbstractController
 
         usort($episodes, fn($item1, $item2) => $item2[1] <=> $item1[1]);
 
-        return array_map(fn($item) => $item[0], array_slice($episodes, 0, $this->maxNextEpisodeShows));
+        return array_map(fn($item) => $item[0], array_slice($episodes, 0, $maxNextEpisodeShows));
     }
 }

--- a/src/main/php/tracky/controller/SettingsController.php
+++ b/src/main/php/tracky/controller/SettingsController.php
@@ -1,0 +1,193 @@
+<?php
+namespace tracky\controller;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use tracky\model\User;
+use tracky\orm\Settings;
+
+class SettingsController extends AbstractController
+{
+    private array $settingsDefinitions = [
+        'overview' => [
+            'type' => 'section',
+            'label' => 'settings.section.overview.label',
+        ],
+        'overviewMaxEpisodes' => [
+            'label'   => 'settings.overview.max-episodes.label',
+            'type'    => 'number',
+            'default' => 8,
+            'min'     => 4,
+            'max'     => 16,
+        ],
+        'overviewMaxMovies' => [
+            'label'   => 'settings.overview.max-movies.label',
+            'type'    => 'number',
+            'default' => 8,
+            'min'     => 4,
+            'max'     => 16,
+        ],
+        'overviewMaxNextEpisodeShows' => [
+            'label'   => 'settings.overview.max-next-episode-shows.label',
+            'type'    => 'number',
+            'default' => 8,
+            'min'     => 4,
+            'max'     => 16,
+        ],
+        /*
+        'exampleSelect' => [
+            'label'   => 'settings.example-select.label',
+            'type'    => 'select',
+            'options' => ['foo' => 'Foo', 'bar' => 'Bar', 'baz' => 'Baz'],
+            'default' => 'foo',
+        ],
+        'exampleText' => [
+            'label'       => 'settings.example-text.label',
+            'type'        => 'text',
+            'placeholder' => 'settings.example-text.placeholder',
+            'regex'       => '^[a-zA-Z0-9\-_]{3,20}$',
+            'default'     => 'anonymous',
+        ],
+        'exampleCheckbox' => [
+            'label'   => 'settings.example-checkbox.label',
+            'type'    => 'checkbox',
+            'options' => [
+                'foo' => 'Foo',
+                'bar' => 'Bar',
+                'baz' => 'Baz'
+            ],
+            'default' => 'foo',
+        ],
+        'exampleRadio' => [
+            'label'       => 'settings.example-radio.label',
+            'type'        => 'radio',
+            'options'     => [
+                'foo' => 'Foo',
+                'bar' => 'Bar'
+            ],
+            'default'     => 'foo',
+        ],
+        */
+    ];
+
+    public function getSettingDefaults(): array
+    {
+        return $this->settingsDefinitions;
+    }
+
+    #[Route("/settings", name: "settings_page")]
+    public function getSettingsPage(EntityManagerInterface $entityManager): Response
+    {
+        $user = $this->getUser();
+        $currentValues = [];
+
+        if ($user) {
+            $savedSettings = $entityManager->getRepository(Settings::class)->findBy(['user' => $user]);
+            foreach ($savedSettings as $setting) {
+                $currentValues[$setting->getSetting()] = $setting->getValue();
+            }
+        }
+
+        $viewSettings = [];
+        foreach ($this->settingsDefinitions as $key => $def) {
+            if ($def['type'] === 'section') {
+                $value = null;
+            } else {
+                $value = $currentValues[$key] ?? $def['default'];
+            }
+
+            $viewSettings[] = [
+                'key'        => $key,
+                'label'      => $def['label'],
+                'type'       => $def['type'],
+                'options'    => $def['options'] ?? [],
+                'value'      => $value,
+                'placeholder'=> $def['placeholder'] ?? null,
+                'min'=> $def['min'] ?? 0,
+                'max'=> $def['max'] ?? 999,
+            ];
+        }
+
+        return $this->render("settings.twig", [
+            'settings' => $viewSettings,
+        ]);
+    }
+
+    #[Route("/settings/update", name: "settings_save_action", methods: ["POST"])]
+    public function saveSettings(Request $request, EntityManagerInterface $entityManager): Response
+    {
+        $hasError = false;
+        $user = $this->getUser();
+
+        if (!$user instanceof User) {
+            return $this->redirectToRoute("login_page");
+        }
+
+        foreach ($this->settingsDefinitions as $key => $def) {
+            $finalValue = '';
+
+            if ($def['type'] === 'section') {
+                continue;
+            }
+
+            if ($def['type'] === 'checkbox') {
+                $inputValues = $request->request->all()[$key] ?? [];
+
+                foreach ($inputValues as $val) {
+                    if (!array_key_exists($val, $def['options'] ?? [])) {
+                        $hasError = true;
+                        break;
+                    }
+                }
+                $finalValue = implode(',', $inputValues);
+            } else {
+                $inputValue = trim($request->request->getString($key, ''));
+                $finalValue = $inputValue !== '' ? $inputValue : $def['default'];
+
+                if ($def['type'] === 'select') {
+                    if (!array_key_exists($finalValue, $def['options'] ?? [])) {
+                        $hasError = true;
+                        continue;
+                    }
+                } elseif ($def['type'] === 'radio') {
+                    if (!in_array($finalValue, array_keys($def['options'] ?? []), true)) {
+                        $hasError = true;
+                        continue;
+                    }
+                } elseif ($def['type'] === 'text') {
+                    if (isset($def['regex']) && !preg_match('/' . $def['regex'] . '/', $finalValue)) {
+                        $hasError = true;
+                        continue;
+                    }
+                } elseif ($def['type'] === 'number') {
+                    $numVal = (int)$finalValue;
+                    if ((string)$numVal !== $finalValue || $numVal < ($def['min'] ?? 0) || $numVal > ($def['max'] ?? PHP_INT_MAX)) {
+                        $hasError = true;
+                        continue;
+                    }
+                }
+            }
+
+            $settingsEntity = $entityManager->getRepository(Settings::class)->findOneBy(['user' => $user, 'setting' => $key]);
+
+            if (!$settingsEntity) {
+                $settingsEntity = new Settings();
+                $settingsEntity->setUser($user);
+                $settingsEntity->setSetting($key);
+            }
+
+            $settingsEntity->setValue($finalValue);
+            $entityManager->persist($settingsEntity);
+
+            if ($hasError) {
+                return $this->redirectToRoute("settings_page", ["flash" => "error"]);
+            }
+        }
+
+        $entityManager->flush();
+        return $this->redirectToRoute("settings_page", ["flash" => "success"]);
+    }
+}

--- a/src/main/php/tracky/orm/Settings.php
+++ b/src/main/php/tracky/orm/Settings.php
@@ -1,0 +1,33 @@
+<?php
+namespace tracky\orm;
+
+use Doctrine\ORM\Mapping as ORM;
+use tracky\model\User;
+
+#[ORM\Entity]
+#[ORM\Table(name: "settings")]
+class Settings
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: "integer")]
+    private int $id;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: "CASCADE")]
+    private User $user;
+
+    #[ORM\Column(type: "string", length: 255)]
+    private string $setting;
+
+    #[ORM\Column(type: "string", length: 255)]
+    private string $value;
+
+    public function getId(): int { return $this->id; }
+    public function getUser(): User { return $this->user; }
+    public function setUser(User $user): self { $this->user = $user; return $this; }
+    public function getSetting(): string { return $this->setting; }
+    public function setSetting(string $setting): self { $this->setting = $setting; return $this; }
+    public function getValue(): string { return $this->value; }
+    public function setValue(string $value): self { $this->value = $value; return $this; }
+}

--- a/src/main/resources/lang/messages+intl-icu.de.yaml
+++ b/src/main/resources/lang/messages+intl-icu.de.yaml
@@ -190,6 +190,26 @@ library-management:
   errors:
     view-exists: "Es gibt bereits einen Verlauf von diesem Eintrag. Bitte vorher entfernen."
 
+settings:
+  title: "Einstellungen"
+  section:
+    overview:
+      label: "Übersicht"
+  flash:
+    saved: "Einstellungen erfolgreich gespeichert."
+    error: "Beim Speichern der Einstellungen ist ein Fehler aufgetreten."
+  overview:
+    max-episodes:
+      label: "Maximale Anzahl anzuzeigender Folgen"
+    max-movies:
+      label: "Maximale Anzahl anzuzeigender Filme"
+    max-next-episode-shows:
+      label: "Maximale Anzahl nächster Folgen"
+  items:
+    label: "Einträge"
+  save:
+    button: "Einstellungen speichern"
+
 date-ranges:
   last-7-days: "Letzte 7 Tage"
   last-30-days: "Letzte 30 Tage"

--- a/src/main/resources/lang/messages+intl-icu.en.yaml
+++ b/src/main/resources/lang/messages+intl-icu.en.yaml
@@ -194,6 +194,26 @@ library-management:
   errors:
     view-exists: "At least one view of this item exists. Remove all views of it and try again."
 
+settings:
+  title: "Settings"
+  section:
+    overview:
+      label: "Overview"
+  flash:
+    saved: "Settings saved successfully."
+    error: "An error occurred while saving settings."
+  overview:
+    max-episodes:
+      label: "Maximum number of episodes to show"
+    max-movies:
+      label: "Maximum number of movies to show"
+    max-next-episode-shows:
+      label: "Maximum number of upcoming episodes to show"
+  items:
+    label: "items"
+  save:
+    button: "Save settings"
+
 date-ranges:
   last-7-days: "Last 7 Days"
   last-30-days: "Last 30 Days"

--- a/templates/page.twig
+++ b/templates/page.twig
@@ -76,7 +76,7 @@
                 <div>
                     <ul class="nav nav-pills flex-column mb-auto">
                         {% if app.user %}
-                            <li class="nav-item"><a class="nav-link"><i class="fa-solid fa-gear"></i> Settings</a></li>
+                            {{ _self.navItem(icon_classes: "fa-solid fa-gear", path: "settings_page", title: "settings.title"|trans) }}
                             {{ _self.navItem(icon_classes: "fa-solid fa-arrow-right-from-bracket", path: "logout", title: "user.logout"|trans) }}
                         {% else %}
                             {{ _self.navItem(icon_classes: "fa-solid fa-arrow-right-to-bracket", path: "login_page", title: "user.login"|trans) }}

--- a/templates/settings.twig
+++ b/templates/settings.twig
@@ -1,0 +1,63 @@
+{% extends "page.twig" %}
+
+    {% block content %}
+        <div class="container mt-4">
+            <h2>{{ "settings.title"|trans }}</h2>
+
+            {% if app.request.query.get('flash') == 'success' %}
+                <div class="alert alert-success">{{ "settings.flash.saved"|trans }}</div>
+            {% elseif app.request.query.get('flash') == 'error' %}
+                <div class="alert alert-danger">{{ "settings.flash.error"|trans|default("An error occurred. Please try again.") }}</div>
+            {% endif %}
+
+            <form method="post" action="{{ path('settings_save_action') }}" class="mt-3">
+                {% for setting in settings %}
+                    <div class="mb-3">
+                        {% if setting.type == 'section' %}
+                            <h3 class="text-primary">{{ setting.label|trans }}</h3>
+                        {% else %}
+                            <label for="{{ setting.key }}" class="form-label">{{ setting.label|trans }}</label>
+
+                            {% if setting.type == 'checkbox' %}
+                                <div class="d-flex gap-2">
+                                    {% set checkedValues = setting.value ? setting.value|split(',') : [] %}
+                                    {% for code, label in setting.options %}
+                                        <div class="form-check">
+                                            <input type="checkbox" name="{{ setting.key }}[]" id="{{ setting.key }}_{{ code }}" value="{{ code }}" class="form-check-input" {{ code in checkedValues ? 'checked' : '' }}>
+                                            <label class="form-check-label" for="{{ setting.key }}_{{ code }}">{{ label|trans }}</label>
+                                        </div>
+                                    {% endfor %}
+                                </div>
+                            {% elseif setting.type == 'number' %}
+                                <div class="input-group">
+                                    <input type="number" name="{{ setting.key }}" id="{{ setting.key }}" class="form-control" value="{{ setting.value }}" min="{{ setting.min }}" max="{{ setting.max }}" />
+                                    <span class="input-group-text">{{ "settings.items.label"|trans }}</span>
+                                </div>
+                            {% elseif setting.type == 'select' %}
+                                <select name="{{ setting.key }}" id="{{ setting.key }}" class="form-select" required>
+                                    {% for code, label in setting.options %}
+                                        <option value="{{ code }}" {{ setting.value == code ? 'selected' : '' }}>{{ label|trans }}</option>
+                                    {% endfor %}
+                                </select>
+                            {% elseif setting.type == 'radio' %}
+                                <div class="d-flex gap-2">
+                                    {% for code, label in setting.options %}
+                                        <div class="form-check">
+                                            <input type="radio" name="{{ setting.key }}" id="{{ setting.key }}_{{ code }}" value="{{ code }}" class="form-check-input" {{ setting.value == code ? 'checked' : '' }} required>
+                                            <label class="form-check-label" for="{{ setting.key }}_{{ code }}">{{ label|trans }}</label>
+                                        </div>
+                                    {% endfor %}
+                                </div>
+                            {% elseif setting.type == 'text' %}
+                                <input type="text" name="{{ setting.key }}" id="{{ setting.key }}" class="form-control" value="{{ setting.value }}" placeholder="{{ setting.placeholder|trans }}" required />
+                            {% endif %}
+                        {% endif %}
+                    </div>
+                {% endfor %}
+
+                <button type="submit" class="btn btn-primary">{{ "settings.save.button"|trans }}</button>
+            </form>
+        </div>
+    {% endblock %}
+
+    {% block title %}{{ "settings.title"|trans }}{% endblock %}


### PR DESCRIPTION
This adds a new settings database table where settings are stored in key-value pairs and assigned to a user id. The settings page is being populated from a single array in SettingsController with many possible setting types. It's possible to configure radio buttons, number inputs, checkboxes, select dropdowns, text input fields and sections to group settings.

As a start, the settings related to the overview page have been removed from the static configuration file and moved over to the user settings page.

<img width="1503" height="1243" alt="image" src="https://github.com/user-attachments/assets/e78000c1-bade-4fbf-9aa5-d9402d8a5be0" />
