### PR TITLE
Add & migrate user settings

### DIFF
--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -14,6 +14,5 @@ parameters:
   user.enable-register: true
   history.items-per-page: 100
   history.max-previous-next-pages: 3
-  shows.max-episodes: 10
   now-watching.storage-path: "%kernel.cache_dir%/now-watching"
   now-watching.max-age: 300

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -29,9 +29,6 @@ services:
     arguments:
       $itemsPerPage: "%history.items-per-page%"
       $maxPreviousNextPages: "%history.max-previous-next-pages%"
-  tracky\controller\ShowController:
-    arguments:
-      $maxEpisodes: "%shows.max-episodes%"
   tracky\controller\UserController:
     arguments:
       $enableRegister: "%user.enable-register%"

--- a/src/main/php/tracky/controller/SettingsController.php
+++ b/src/main/php/tracky/controller/SettingsController.php
@@ -37,6 +37,19 @@ class SettingsController extends AbstractController
             "min"     => 4,
             "max"     => 16,
         ],
+        "shows" => [
+            "type" => "section",
+            "label" => "settings.section.shows.label",
+        ],
+        "hideShows" => [
+            "label"   => "settings.shows.hide-shows.label",
+            "type"    => "checkbox",
+            "options" => [
+                "ended"    => "settings.shows.hide-shows.option.ended",
+                "finished" => "settings.shows.hide-shows.option.finished",
+            ],
+            "default" => "",
+        ],
         /*
         "exampleSelect" => [
             "label"   => "settings.example-select.label",
@@ -50,16 +63,6 @@ class SettingsController extends AbstractController
             "placeholder" => "settings.example-text.placeholder",
             "regex"       => "^[a-zA-Z0-9\-_]{3,20}$",
             "default"     => "anonymous",
-        ],
-        "exampleCheckbox" => [
-            "label"   => "settings.example-checkbox.label",
-            "type"    => "checkbox",
-            "options" => [
-                "foo" => "Foo",
-                "bar" => "Bar",
-                "baz" => "Baz"
-            ],
-            "default" => "foo",
         ],
         "exampleRadio" => [
             "label"       => "settings.example-radio.label",

--- a/src/main/php/tracky/controller/SettingsController.php
+++ b/src/main/php/tracky/controller/SettingsController.php
@@ -54,6 +54,7 @@ class SettingsController extends AbstractController
             "options" => [
                 "ended"    => "settings.shows.hide-shows.option.ended",
                 "finished" => "settings.shows.hide-shows.option.finished",
+                "unwatched" => "settings.shows.hide-shows.option.unwatched",
             ],
             "default" => "",
         ],

--- a/src/main/php/tracky/controller/SettingsController.php
+++ b/src/main/php/tracky/controller/SettingsController.php
@@ -41,6 +41,13 @@ class SettingsController extends AbstractController
             "type" => "section",
             "label" => "settings.section.shows.label",
         ],
+        "showsMaxEpisodes" => [
+            "label"   => "settings.shows.max-episodes.label",
+            "type"    => "number",
+            "default" => 10,
+            "min"     => 5,
+            "max"     => 60,
+        ],
         "hideShows" => [
             "label"   => "settings.shows.hide-shows.label",
             "type"    => "checkbox",

--- a/src/main/php/tracky/controller/ShowController.php
+++ b/src/main/php/tracky/controller/ShowController.php
@@ -19,6 +19,7 @@ use tracky\model\Episode;
 use tracky\model\Season;
 use tracky\model\Show;
 use tracky\model\View;
+use tracky\orm\Settings;
 use tracky\orm\ShowRepository;
 use tracky\orm\ViewRepository;
 use tracky\ViewType;
@@ -29,6 +30,7 @@ class ShowController extends AbstractController
     public function __construct(
         private readonly ShowRepository $showRepository,
         private readonly ViewRepository $viewRepository,
+        private readonly SettingsController $settingsController,
         private readonly int $maxEpisodes,
     )
     {
@@ -68,10 +70,20 @@ class ShowController extends AbstractController
     }
 
     #[Route("/shows", name: "shows_page")]
-    public function getShowsPage(): Response
+    public function getShowsPage(EntityManagerInterface $entityManager): Response
     {
+        $user = $this->getUser();
+        if ($user !== null) {
+            $savedSettings = $entityManager->getRepository(Settings::class)->findBy(['user' => $user]);
+            foreach ($savedSettings as $setting) {
+                if ($setting->getSetting() === 'hideShows') {
+                    $hideShows = (string)$setting->getValue();
+                }
+            }
+        }
         return $this->render("shows/shows.twig", [
-            "shows" => $this->showRepository->findAllWithEpisodes()
+            "shows" => $this->showRepository->findAllWithEpisodes(),
+            "hideShows" => $hideShows ?? null,
         ]);
     }
 

--- a/src/main/php/tracky/controller/ShowController.php
+++ b/src/main/php/tracky/controller/ShowController.php
@@ -31,7 +31,6 @@ class ShowController extends AbstractController
         private readonly ShowRepository $showRepository,
         private readonly ViewRepository $viewRepository,
         private readonly SettingsController $settingsController,
-        private readonly int $maxEpisodes,
     )
     {
     }
@@ -72,18 +71,11 @@ class ShowController extends AbstractController
     #[Route("/shows", name: "shows_page")]
     public function getShowsPage(EntityManagerInterface $entityManager): Response
     {
-        $user = $this->getUser();
-        if ($user !== null) {
-            $savedSettings = $entityManager->getRepository(Settings::class)->findBy(['user' => $user]);
-            foreach ($savedSettings as $setting) {
-                if ($setting->getSetting() === 'hideShows') {
-                    $hideShows = (string)$setting->getValue();
-                }
-            }
-        }
+        $settings = $this->getSettings($entityManager);
+
         return $this->render("shows/shows.twig", [
             "shows" => $this->showRepository->findAllWithEpisodes(),
-            "hideShows" => $hideShows ?? null,
+            "hideShows" => $settings['hideShows'],
         ]);
     }
 
@@ -123,56 +115,60 @@ class ShowController extends AbstractController
     }
 
     #[Route("/shows/{show}/random-episodes", name: "shows_random_episodes_page")]
-    public function getRandomEpisodesPage(int $show): Response
+    public function getRandomEpisodesPage(int $show, EntityManagerInterface $entityManager): Response
     {
+        $settings = $this->getSettings($entityManager);
         $show = $this->showRepository->findByIdWithEpisodes($show);
 
         return $this->render("shows/episodes.twig", [
             "show" => $show,
             "title" => "shows.random-episodes",
-            "episodes" => $show->getRandomEpisodes($this->maxEpisodes),
+            "episodes" => $show->getRandomEpisodes($settings['showsMaxEpisodes']),
             "displaySeason" => true
         ]);
     }
 
     #[Route("/shows/{show}/latest-watched", name: "shows_latest_watched_episodes_page")]
     #[IsGranted("IS_AUTHENTICATED")]
-    public function getLatestWatchedEpisodesPage(int $show, WatchStatsProvider $watchStatsProvider): Response
+    public function getLatestWatchedEpisodesPage(int $show, WatchStatsProvider $watchStatsProvider, EntityManagerInterface $entityManager): Response
     {
+        $settings = $this->getSettings($entityManager);
         $show = $this->showRepository->findByIdWithEpisodes($show);
 
         return $this->render("shows/episodes.twig", [
             "show" => $show,
             "title" => "shows.latest-watched-episodes",
-            "episodes" => array_map(fn($item) => $item[0], $show->getLatestWatchedEpisodes($watchStatsProvider, $this->maxEpisodes)),
+            "episodes" => array_map(fn($item) => $item[0], $show->getLatestWatchedEpisodes($watchStatsProvider, $settings['showsMaxEpisodes'])),
             "displaySeason" => true
         ]);
     }
 
     #[Route("/shows/{show}/most-watched", name: "shows_most_watched_episodes_page")]
     #[IsGranted("IS_AUTHENTICATED")]
-    public function getMostWatchedEpisodesPage(int $show, WatchStatsProvider $watchStatsProvider): Response
+    public function getMostWatchedEpisodesPage(int $show, WatchStatsProvider $watchStatsProvider, EntityManagerInterface $entityManager): Response
     {
+        $settings = $this->getSettings($entityManager);
         $show = $this->showRepository->findByIdWithEpisodes($show);
 
         return $this->render("shows/episodes.twig", [
             "show" => $show,
             "title" => "shows.most-watched-episodes",
-            "episodes" => array_map(fn($item) => $item[0], $show->getMostOrLeastWatchedEpisodes($watchStatsProvider, $this->maxEpisodes, false)),
+            "episodes" => array_map(fn($item) => $item[0], $show->getMostOrLeastWatchedEpisodes($watchStatsProvider, $settings['showsMaxEpisodes'], false)),
             "displaySeason" => true
         ]);
     }
 
     #[Route("/shows/{show}/least-watched", name: "shows_least_watched_episodes_page")]
     #[IsGranted("IS_AUTHENTICATED")]
-    public function getLeastWatchedEpisodesPage(int $show, WatchStatsProvider $watchStatsProvider): Response
+    public function getLeastWatchedEpisodesPage(int $show, WatchStatsProvider $watchStatsProvider, EntityManagerInterface $entityManager): Response
     {
+        $settings = $this->getSettings($entityManager);
         $show = $this->showRepository->findByIdWithEpisodes($show);
 
         return $this->render("shows/episodes.twig", [
             "show" => $show,
             "title" => "shows.least-watched-episodes",
-            "episodes" => array_map(fn($item) => $item[0], $show->getMostOrLeastWatchedEpisodes($watchStatsProvider, $this->maxEpisodes, true)),
+            "episodes" => array_map(fn($item) => $item[0], $show->getMostOrLeastWatchedEpisodes($watchStatsProvider, $settings['showsMaxEpisodes'], true)),
             "displaySeason" => true
         ]);
     }
@@ -376,5 +372,33 @@ class ShowController extends AbstractController
         }
 
         return $this->file($path, null, ResponseHeaderBag::DISPOSITION_INLINE);
+    }
+
+    private function getSettings(EntityManagerInterface $entityManager): array
+    {
+        $defaults = $this->settingsController->getSettingDefaults();
+
+        $settings = [
+            'showsMaxEpisodes' => (int)($defaults['showsMaxEpisodes']['default'] ?? 10),
+            'hideShows' => null,
+        ];
+
+        $user = $this->getUser();
+        if ($user !== null) {
+            $savedSettings = $entityManager->getRepository(Settings::class)->findBy(['user' => $user]);
+
+            foreach ($savedSettings as $setting) {
+                switch ($setting->getSetting()) {
+                    case 'showsMaxEpisodes':
+                        $settings['showsMaxEpisodes'] = (int)$setting->getValue();
+                        break;
+                    case 'hideShows':
+                        $settings['hideShows'] = $setting->getValue() ?: null;
+                        break;
+                }
+            }
+        }
+
+        return $settings;
     }
 }

--- a/src/main/php/tracky/controller/ShowController.php
+++ b/src/main/php/tracky/controller/ShowController.php
@@ -75,7 +75,7 @@ class ShowController extends AbstractController
 
         return $this->render("shows/shows.twig", [
             "shows" => $this->showRepository->findAllWithEpisodes(),
-            "hideShows" => $settings['hideShows'],
+            "hideShows" => $settings["hideShows"],
         ]);
     }
 
@@ -123,7 +123,7 @@ class ShowController extends AbstractController
         return $this->render("shows/episodes.twig", [
             "show" => $show,
             "title" => "shows.random-episodes",
-            "episodes" => $show->getRandomEpisodes($settings['showsMaxEpisodes']),
+            "episodes" => $show->getRandomEpisodes($settings["showsMaxEpisodes"]),
             "displaySeason" => true
         ]);
     }
@@ -138,7 +138,7 @@ class ShowController extends AbstractController
         return $this->render("shows/episodes.twig", [
             "show" => $show,
             "title" => "shows.latest-watched-episodes",
-            "episodes" => array_map(fn($item) => $item[0], $show->getLatestWatchedEpisodes($watchStatsProvider, $settings['showsMaxEpisodes'])),
+            "episodes" => array_map(fn($item) => $item[0], $show->getLatestWatchedEpisodes($watchStatsProvider, $settings["showsMaxEpisodes"])),
             "displaySeason" => true
         ]);
     }
@@ -153,7 +153,7 @@ class ShowController extends AbstractController
         return $this->render("shows/episodes.twig", [
             "show" => $show,
             "title" => "shows.most-watched-episodes",
-            "episodes" => array_map(fn($item) => $item[0], $show->getMostOrLeastWatchedEpisodes($watchStatsProvider, $settings['showsMaxEpisodes'], false)),
+            "episodes" => array_map(fn($item) => $item[0], $show->getMostOrLeastWatchedEpisodes($watchStatsProvider, $settings["showsMaxEpisodes"], false)),
             "displaySeason" => true
         ]);
     }
@@ -168,7 +168,7 @@ class ShowController extends AbstractController
         return $this->render("shows/episodes.twig", [
             "show" => $show,
             "title" => "shows.least-watched-episodes",
-            "episodes" => array_map(fn($item) => $item[0], $show->getMostOrLeastWatchedEpisodes($watchStatsProvider, $settings['showsMaxEpisodes'], true)),
+            "episodes" => array_map(fn($item) => $item[0], $show->getMostOrLeastWatchedEpisodes($watchStatsProvider, $settings["showsMaxEpisodes"], true)),
             "displaySeason" => true
         ]);
     }
@@ -379,21 +379,21 @@ class ShowController extends AbstractController
         $defaults = $this->settingsController->getSettingDefaults();
 
         $settings = [
-            'showsMaxEpisodes' => (int)($defaults['showsMaxEpisodes']['default'] ?? 10),
-            'hideShows' => null,
+            "showsMaxEpisodes" => (int)($defaults["showsMaxEpisodes"]["default"] ?? 10),
+            "hideShows" => null,
         ];
 
         $user = $this->getUser();
         if ($user !== null) {
-            $savedSettings = $entityManager->getRepository(Settings::class)->findBy(['user' => $user]);
+            $savedSettings = $entityManager->getRepository(Settings::class)->findBy(["user" => $user]);
 
             foreach ($savedSettings as $setting) {
                 switch ($setting->getSetting()) {
-                    case 'showsMaxEpisodes':
-                        $settings['showsMaxEpisodes'] = (int)$setting->getValue();
+                    case "showsMaxEpisodes":
+                        $settings["showsMaxEpisodes"] = (int)$setting->getValue();
                         break;
-                    case 'hideShows':
-                        $settings['hideShows'] = $setting->getValue() ?: null;
+                    case "hideShows":
+                        $settings["hideShows"] = $setting->getValue() ?: null;
                         break;
                 }
             }

--- a/src/main/resources/lang/messages+intl-icu.de.yaml
+++ b/src/main/resources/lang/messages+intl-icu.de.yaml
@@ -195,6 +195,8 @@ settings:
   section:
     overview:
       label: "Übersicht"
+    shows:
+      label: "Serien"
   flash:
     saved: "Einstellungen erfolgreich gespeichert."
     error: "Beim Speichern der Einstellungen ist ein Fehler aufgetreten."
@@ -205,6 +207,12 @@ settings:
       label: "Maximale Anzahl anzuzeigender Filme"
     max-next-episode-shows:
       label: "Maximale Anzahl nächster Folgen"
+  shows:
+    hide-shows:
+      label: "Serien ausblenden"
+      option:
+        ended: "Beendete Serien"
+        finished: "Vollständig angesehene Serien"
   items:
     label: "Einträge"
   save:

--- a/src/main/resources/lang/messages+intl-icu.de.yaml
+++ b/src/main/resources/lang/messages+intl-icu.de.yaml
@@ -114,6 +114,7 @@ shows:
   no-shows-available: "Keine Serien verfügbar."
   no-seasons-available: "Keine Staffeln verfügbar."
   no-episodes-available: "Keine Folgen verfügbar."
+  some-shows-hidden: "Filter-Einstellungen sind aktiv. Einige Serien könnten ausgeblendet sein."
   add-new: "Serie hinzufügen"
   status:
     upcoming: "Geplant"

--- a/src/main/resources/lang/messages+intl-icu.de.yaml
+++ b/src/main/resources/lang/messages+intl-icu.de.yaml
@@ -215,6 +215,7 @@ settings:
       option:
         ended: "Beendete Serien"
         finished: "Vollständig angesehene Serien"
+        unwatched: "Nicht angefangene Serien"
   items:
     label: "Einträge"
   save:

--- a/src/main/resources/lang/messages+intl-icu.de.yaml
+++ b/src/main/resources/lang/messages+intl-icu.de.yaml
@@ -208,6 +208,8 @@ settings:
     max-next-episode-shows:
       label: "Maximale Anzahl nächster Folgen"
   shows:
+    max-episodes:
+      label: "Maximale Anzahl von Folgen auf Serien-Unterseiten (außer Staffeln und ungesehene Folgen)"
     hide-shows:
       label: "Serien ausblenden"
       option:

--- a/src/main/resources/lang/messages+intl-icu.en.yaml
+++ b/src/main/resources/lang/messages+intl-icu.en.yaml
@@ -114,6 +114,7 @@ shows:
   no-shows-available: "No shows available."
   no-seasons-available: "No seasons available."
   no-episodes-available: "No episodes available."
+  some-shows-hidden: "Filter settings are active. Some shows might be hidden."
   add-new: "Add show"
   status:
     upcoming: "Upcoming"

--- a/src/main/resources/lang/messages+intl-icu.en.yaml
+++ b/src/main/resources/lang/messages+intl-icu.en.yaml
@@ -212,6 +212,8 @@ settings:
     max-next-episode-shows:
       label: "Maximum number of upcoming episodes to show"
   shows:
+    max-episodes:
+      label: "Maximum number of episodes on show subpages (except seasons and unwatched episodes)"
     hide-shows:
       label: "Hide shows"
       option:

--- a/src/main/resources/lang/messages+intl-icu.en.yaml
+++ b/src/main/resources/lang/messages+intl-icu.en.yaml
@@ -199,6 +199,8 @@ settings:
   section:
     overview:
       label: "Overview"
+    shows:
+      label: "Shows"
   flash:
     saved: "Settings saved successfully."
     error: "An error occurred while saving settings."
@@ -209,6 +211,12 @@ settings:
       label: "Maximum number of movies to show"
     max-next-episode-shows:
       label: "Maximum number of upcoming episodes to show"
+  shows:
+    hide-shows:
+      label: "Hide shows"
+      option:
+        ended: "Ended shows"
+        finished: "Fully watched shows"
   items:
     label: "items"
   save:

--- a/src/main/resources/lang/messages+intl-icu.en.yaml
+++ b/src/main/resources/lang/messages+intl-icu.en.yaml
@@ -219,6 +219,7 @@ settings:
       option:
         ended: "Ended shows"
         finished: "Fully watched shows"
+        unwatched: "Not yet started shows"
   items:
     label: "items"
   save:

--- a/templates/components/show-list-small.twig
+++ b/templates/components/show-list-small.twig
@@ -4,7 +4,8 @@
 
         {% if not (
             ('ended' in hideOptions and show.status == 'ended') or
-            ('finished' in hideOptions and show.getWatchProgress(watchStatsProvider) == 100)
+            ('finished' in hideOptions and show.getWatchProgress(watchStatsProvider) == 100) or
+            ('unwatched' in hideOptions and show.getWatchProgress(watchStatsProvider) == 0)
         ) %}
             <div class="col">
                 {% include "components/show-card-small.twig" with {"show": show} %}

--- a/templates/components/show-list-small.twig
+++ b/templates/components/show-list-small.twig
@@ -1,11 +1,11 @@
 <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 row-cols-xl-4 g-4">
     {% for show in shows %}
-        {% set hideOptions = hideShows|default('')|split(',') %}
+        {% set hideOptions = hideShows|default("")|split(",") %}
 
         {% if not (
-            ('ended' in hideOptions and show.status == 'ended') or
-            ('finished' in hideOptions and show.getWatchProgress(watchStatsProvider) == 100) or
-            ('unwatched' in hideOptions and show.getWatchProgress(watchStatsProvider) == 0)
+            ("ended" in hideOptions and show.status == "ended") or
+            ("finished" in hideOptions and show.getWatchProgress(watchStatsProvider) == 100) or
+            ("unwatched" in hideOptions and show.getWatchProgress(watchStatsProvider) == 0)
         ) %}
             <div class="col">
                 {% include "components/show-card-small.twig" with {"show": show} %}

--- a/templates/components/show-list-small.twig
+++ b/templates/components/show-list-small.twig
@@ -1,7 +1,14 @@
 <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 row-cols-xl-4 g-4">
     {% for show in shows %}
-        <div class="col">
-            {% include "components/show-card-small.twig" with {"show": show} %}
-        </div>
+        {% set hideOptions = hideShows|default('')|split(',') %}
+
+        {% if not (
+            ('ended' in hideOptions and show.status == 'ended') or
+            ('finished' in hideOptions and show.getWatchProgress(watchStatsProvider) == 100)
+        ) %}
+            <div class="col">
+                {% include "components/show-card-small.twig" with {"show": show} %}
+            </div>
+        {% endif %}
     {% endfor %}
 </div>

--- a/templates/shows/shows.twig
+++ b/templates/shows/shows.twig
@@ -5,6 +5,11 @@
 {% block content %}
     <h1>{{ "shows.all-shows"|trans }}</h1>
 
+    {% set hideOptions = hideShows|default('')|split(',') %}
+    {% if hideOptions|filter(value => value != '')|length > 0 %}
+        <div class="alert alert-info">{{ "shows.some-shows-hidden"|trans }}</div>
+    {% endif %}
+
     <small class="d-block">{{ "shows.count.shows"|trans({"%count%": shows|length}) }}</small>
 
     {% if is_granted("IS_AUTHENTICATED") %}

--- a/templates/shows/shows.twig
+++ b/templates/shows/shows.twig
@@ -5,8 +5,8 @@
 {% block content %}
     <h1>{{ "shows.all-shows"|trans }}</h1>
 
-    {% set hideOptions = hideShows|default('')|split(',') %}
-    {% if hideOptions|filter(value => value != '')|length > 0 %}
+    {% set hideOptions = hideShows|default("")|split(",") %}
+    {% if hideOptions|filter(value => value != "")|length > 0 %}
         <div class="alert alert-info">{{ "shows.some-shows-hidden"|trans }}</div>
     {% endif %}
 


### PR DESCRIPTION
Added a setting to hide shows that have ended, been fully watched or not even started watching yet. If it's checked, a notification on the shows page will appear, reminding users they set that option:

<img width="802" height="539" alt="image" src="https://github.com/user-attachments/assets/89ae452b-182a-49f6-9aa8-56f8f075483c" />

Also migrated the shows.max-episodes setting from defaults.yaml to user settings.